### PR TITLE
Add eachbyte and eachint iterators

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -12,6 +12,7 @@ Graphs = "86223c79-3864-5bf0-83f7-82e725a168b6"
 MetaGraphs = "626554b9-1ddb-594c-aa3c-2596fe9399a5"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 ProgressMeter = "92933f4c-e287-5a05-a399-4b506db050ca"
+StringViews = "354b36f9-a18e-4713-926e-db85100087ba"
 
 [compat]
 julia = "1.8"

--- a/src/AoCElfTools.jl
+++ b/src/AoCElfTools.jl
@@ -110,4 +110,5 @@ export daysavailable
   include("io.jl")
   export eachbyte
   export iterate
+  export eachint
 end

--- a/src/AoCElfTools.jl
+++ b/src/AoCElfTools.jl
@@ -105,4 +105,9 @@ export solve_specific
 export yearsavailable
 export daysavailable
 
+  
+  # Include IO functions
+  include("io.jl")
+  export eachbyte
+  export iterate
 end

--- a/src/AoCElfTools.jl
+++ b/src/AoCElfTools.jl
@@ -109,6 +109,5 @@ export daysavailable
   # Include IO functions
   include("io.jl")
   export eachbyte
-  export iterate
   export eachint
 end

--- a/src/io.jl
+++ b/src/io.jl
@@ -1,0 +1,55 @@
+
+struct EachByte{IOT<:IO}
+  stream::IOT
+  ondone::Function
+  EachByte(stream::IO=stdin; ondone::Function=()->nothing) = new{typeof(stream)}(stream, ondone)
+end
+
+"""
+    eachbyte(io::IO=stdin)
+    eachbyte(filename::AbstractString)
+
+Create an iterable `EachByte` object that will yield each byte from an I/O stream or a file.
+Iteration calls [`read`](@ref) on the stream argument repeatedly. When called with a file name,
+the file is opened once at the beginning of iteration and closed at the end. If iteration is
+interrupted, the file will be closed when the `EachByte` object is garbage collected.
+
+# Examples
+```jldoctest
+julia> open("my_file.txt", "w") do io
+  write(io, "\0\1\2\3\4");
+end;
+
+julia> for byte in eachbyte("my_file.txt")
+@show byte
+end
+byte = 0x00
+byte = 0x01
+byte = 0x02
+byte = 0x03
+byte = 0x04
+
+julia> rm("my_file.txt");
+````
+"""
+function eachbyte(stream::IO=stdin)
+  EachByte(stream)::EachByte
+end
+
+function eachbyte(filename::AbstractString)
+  bs = open(filename)
+  EachByte(bs, ondone=()->close(bs))::EachByte
+end
+
+function Base.iterate(itr::EachByte, state=nothing)
+  eof(itr.stream) && return (itr.ondone(); nothing)
+  (read(itr.stream, UInt8)::UInt8, nothing)
+end
+
+eltype(::Type{<:EachByte}) = UInt8
+
+Base.IteratorSize(::Type{<:EachByte}) = Base.SizeUnknown()
+
+isdone(itr::EachByte, state...) = eof(itr.stream)
+
+

--- a/test/io.jl
+++ b/test/io.jl
@@ -47,3 +47,59 @@ end
     rm(path)
   end
 end
+
+
+onetoten = ascii("1 2 3 4 5 6 7 8 9 10")
+onetotennewlines = ascii("1 2 3 4\n5 6 7 8\n9 10")
+onetotenint = 1:10
+
+negatives = ascii("1 -2 3 4 5 6 -7 8 -9 10")
+negativesnewlines = ascii("1 -2 3 4\n5 6 -7 8\n-9 10")
+negativesint = [1, -2, 3, 4, 5, 6, -7, 8, -9, 10]
+
+@testset "eachint" begin
+  for (desc, str, int) in [
+    ("no newlines", onetoten, onetotenint),
+    ("newlines", onetotennewlines, onetotenint),
+    ("no newlines, negatives", negatives, negativesint),
+    ("newlines, negatives", negativesnewlines, negativesint),
+  ]
+
+    @testset "EOF" begin
+      for (desc, eolstr) in [
+        ("no EOL @ EOF", ""),
+        ("no whitespace after last line", ""),
+        ("whitespace after last line", "\n"),
+        ("whitespace after last line, windows", "\r\n"),
+      ]
+
+        (path, io) = mktemp(; cleanup=false)
+        write(path, str * eolstr)
+        close(io)
+        iob = IOBuffer(str)
+
+        @testset "IO" begin
+          eb = eachint(iob)
+          @test !AoCElfTools.isdone(eb)
+          for (i, ii) in enumerate(eb)
+            @test int[i] == ii
+          end
+          @test AoCElfTools.isdone(eb)
+        end
+
+        @testset "file" begin
+          eb = eachint(path)
+          @test !AoCElfTools.isdone(eb)
+          for (i, ii) in enumerate(eb)
+            @test int[i] == ii
+          end
+          @test AoCElfTools.isdone(eb)
+        end
+
+        rm(path)
+      end
+    end
+
+  end
+
+end

--- a/test/io.jl
+++ b/test/io.jl
@@ -54,7 +54,7 @@ onetotennewlines = ascii("1 2 3 4\n5 6 7 8\n9 10")
 onetotenint = 1:10
 
 negatives = ascii("1 -2 3 4 5 6 -7 8 -9 10")
-negativesnewlines = ascii("1 -2 3 4\n5 6 -7 8\n-9 10")
+negativesnewlines = ascii("1 -2 3 4\n5 6   -7 \t8\n-9 10") # also includes some extra spaces and a tab
 negativesint = [1, -2, 3, 4, 5, 6, -7, 8, -9, 10]
 
 @testset "eachint" begin

--- a/test/io.jl
+++ b/test/io.jl
@@ -22,3 +22,28 @@
     rm(path)
   end
 end
+
+@testset "eachint" begin
+  @testset "IO" begin
+    io = IOBuffer(ascii("1 2 3 4 5 6 7 8 9 10"))
+    eb = eachint(io)
+    @test !AoCElfTools.isdone(eb)
+    for (i, ii) in enumerate(eb)
+      @test i == ii
+    end
+    @test AoCElfTools.isdone(eb)
+  end
+
+  @testset "file" begin
+    (path, io) = mktemp(; cleanup=false)
+    write(path, ascii("1 2 3 4 5 6 7 8 9 10"))
+    close(io)
+    eb = eachint(path)
+    @test !AoCElfTools.isdone(eb)
+    for (i, ii) in enumerate(eb)
+      @test i == ii
+    end
+    @test AoCElfTools.isdone(eb)
+    rm(path)
+  end
+end

--- a/test/io.jl
+++ b/test/io.jl
@@ -1,0 +1,24 @@
+@testset "eachbyte" begin
+  @testset "IO" begin
+    io = IOBuffer(Vector{UInt8}(1:10))
+    eb = eachbyte(io)
+    @test !AoCElfTools.isdone(eb)
+    for (i, b) in enumerate(eb)
+      @test i == b
+    end
+    @test AoCElfTools.isdone(eb)
+  end
+
+  @testset "file" begin
+    (path, io) = mktemp(; cleanup=false)
+    write(path, Vector{UInt8}(1:10))
+    close(io)
+    eb = eachbyte(path)
+    @test !AoCElfTools.isdone(eb)
+    for (i, b) in enumerate(eb)
+      @test i == b
+    end
+    @test AoCElfTools.isdone(eb)
+    rm(path)
+  end
+end

--- a/test/puzzles.jl
+++ b/test/puzzles.jl
@@ -1,0 +1,12 @@
+"""
+Helper function, expects a string input of the form "/path/to/YYYY/DD.jl" and returns a tuple of the day (DD) as an integer, the day as a string, and the year as an integer.
+"""
+function check_day(filepath)
+  istr = filepath |> basename |> splitext |> first
+  year = filepath |> splitdir |> first |> splitdir |> last
+  return parse(Int, istr), istr, parse(Int, year)
+end
+
+@testset verbose = true for year in yearsavailable()
+    include(joinpath(@__DIR__, string(year), string(year)) * ".jl")
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,20 +4,4 @@ using Test
 using Printf
 
 include("io.jl")
-
-
-
-"""
-Helper function, expects a string input of the form "/path/to/YYYY/DD.jl" and returns a tuple of the day (DD) as an integer, the day as a string, and the year as an integer.
-"""
-function check_day(filepath)
-  istr = filepath |> basename |> splitext |> first
-  year = filepath |> splitdir |> first |> splitdir |> last
-  return parse(Int, istr), istr, parse(Int, year)
-end
-
-@testset verbose = true begin
-  for year in yearsavailable()
-    include(joinpath(@__DIR__, string(year), string(year)) * ".jl")
-  end
-end
+# include("puzzles.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,4 +4,4 @@ using Test
 using Printf
 
 include("io.jl")
-# include("puzzles.jl")
+include("puzzles.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,6 +3,10 @@ using AoCElfTools: samplepath, userpath
 using Test
 using Printf
 
+include("io.jl")
+
+
+
 """
 Helper function, expects a string input of the form "/path/to/YYYY/DD.jl" and returns a tuple of the day (DD) as an integer, the day as a string, and the year as an integer.
 """


### PR DESCRIPTION
For convenient iteration over bytes or (especially, for AoC) whitespace-separated integers in a file.

Supersedes #21 